### PR TITLE
init: error out if no IP address is acquired

### DIFF
--- a/libexec/init
+++ b/libexec/init
@@ -123,7 +123,11 @@ get_external_ip() {
 		fi
 	done
 
-	echo $external_ip
+    if [ "$external_ip" == "N/A" ]; then
+        return 1
+    else
+        echo $external_ip
+    fi
 }
 
 bottom_pane() {

--- a/libexec/init
+++ b/libexec/init
@@ -124,9 +124,9 @@ get_external_ip() {
 	done
 
     if [ "$external_ip" == "N/A" ]; then
-        return 1
+    	return 1
     else
-        echo $external_ip
+    	echo $external_ip
     fi
 }
 


### PR DESCRIPTION
Currently, if the system is unable to acquire an IP address, the
`get_external_ip` function will return `N\A`.  This is a successful
return and the check at line 69 will succeed and proceed to try and
download the Cockpit image.

This changes the behavior of `get_external_ip` to return `1` if it is
determined there is no IP address assigned to the system. This should
cause the init script to error and stop.

Fixes #3