### PR TITLE
 bootcmd: don't expire the root password there  We

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ archive:
 	fi
 	@REF=$${REF:-HEAD}; \
 	git archive --format=tar.gz --prefix=atomic-devmode/ \
-		$$REF > atomic-devmode.tar.gz && \
-	echo "$$REF > atomic-devmode.tar.gz"
+		$$REF > atomic-devmode-$$REF.tar.gz && \
+	echo "$$REF > atomic-devmode-$$REF.tar.gz"

--- a/libexec/bash_profile
+++ b/libexec/bash_profile
@@ -37,6 +37,12 @@ if [[ $- == *i* ]] && [[ $(tty) == /dev/tty1 ]] && [[ -z "${TMUX-}" ]]; then
     # it doesn't pollute the tmux screen
     dmesg -n 1
 
+    # mark the password as expired so that cockpit requests
+    # a password reset on first login -- we can't do this in
+    # bootcmd otherwise agetty will prompt for the password
+    # reset during autologin
+    chage -d 0 root
+
     exec tmux -f /usr/share/atomic-devmode/tmux.conf \
         new-session -s devmode -n main \
             /usr/libexec/atomic-devmode/init

--- a/libexec/bootcmd
+++ b/libexec/bootcmd
@@ -75,10 +75,6 @@ $LIBEXEC/pwmake_friendly 64 \
 chmod 600 /run/atomic-devmode-root
 passwd -u root >/dev/null
 
-# mark the password as expired so that cockpit requests a
-# password reset on first login
-chage -d 0 root
-
 # 4. sshd configuration
 
 # We have to make sure that sshd accepts challenge-response

--- a/libexec/init
+++ b/libexec/init
@@ -61,9 +61,9 @@ top_pane() {
 		return
 	fi
 
-	echo    "Password for root:  $(cat /run/atomic-devmode-root)"
+	echo    "Temporary password for root:  $(cat /run/atomic-devmode-root)"
 
-	echo -n "IP address:         < waiting... > "
+	echo -n "IP address:                   < waiting... > "
 
 	ip=$(get_external_ip)
 	if [ $? -ne 0 ]; then
@@ -72,9 +72,9 @@ top_pane() {
 		return
 	fi
 
-	echo -e "\rIP address:         $ip"
+	echo -e "\rIP address:                   $ip"
 
-	echo -n "Cockpit console:    < downloading... > "
+	echo -n "Cockpit console:              < downloading... > "
 
 	while [ ! -f /run/atomic-devmode-cockpit.rc ]; do
 		sleep 1
@@ -87,7 +87,7 @@ top_pane() {
 		return
 	fi
 
-	echo -e "\rCockpit console:    https://$ip:9090/"
+	echo -e "\rCockpit console:              https://$ip:9090/"
 	echo
 
 	echo "You can now log in the Cockpit console with"


### PR DESCRIPTION
We should expire it in init instead so that agetty doesn't prompt for a
new password during autologin.

Also tweak welcome message.