### PR TITLE
init: install cockpit/ws before running

### DIFF
--- a/libexec/init
+++ b/libexec/init
@@ -144,7 +144,8 @@ bottom_pane() {
 	fi
 
 	rc=0
-	atomic run cockpit/ws || rc=$?
+	(atomic install cockpit/ws &&
+	 atomic run cockpit/ws) || rc=$?
 	echo $rc > /run/atomic-devmode-cockpit.rc
 	journalctl -f
 }


### PR DESCRIPTION
The atomic CLI changed behaviour recently (in
https://github.com/projectatomic/atomic/pull/950), to require containers
with `INSTALL` labels to be explicitly installed before being run. This is
probably something we should have done to begin with.

Downstream RHBZ: #1454439